### PR TITLE
BUG: week-string - missing from org-gantt-strings-to-time function.

### DIFF
--- a/experiments/org-gantt.el
+++ b/experiments/org-gantt.el
@@ -535,7 +535,7 @@ that are converted to numbers. Then the time is calculated from the values."
               (* 60 (org-gantt-string-to-number minutes-string))
               (* 3600 (org-gantt-string-to-number hours-string))
               (* 3600 (or hours-per-day (org-gantt-hours-per-day)) (org-gantt-string-to-number days-string))
-              (* 3600 (or hours-per-day (org-gantt-hours-per-day)) (- 7 (length work-free-days)))
+              (* 3600 (or hours-per-day (org-gantt-hours-per-day)) (- 7 (length work-free-days)) (org-gantt-string-to-number weeks-string))
               (* 3600 (or hours-per-day (org-gantt-hours-per-day)) 30 (org-gantt-string-to-number months-string))
               (* 3600 (or hours-per-day (org-gantt-hours-per-day)) 30 12 (org-gantt-string-to-number years-string))))))
     (if (= 0 (apply '+ time))


### PR DESCRIPTION
Hi, I found your org-gantt.el miraculously on google. And boy was it what I was looking for. It's really great, thanks for sharing your work.

Unfortunately, I could never get the effort estimates to work with the chart. It seemed to always be about AT LEAST ONE week for EACH TASK. I managed to track the bug down to your org-gantt-strings-to-time function, and now it seems to work a treat! 
